### PR TITLE
feat(keyboard) selection tool love

### DIFF
--- a/docs/editor-client.md
+++ b/docs/editor-client.md
@@ -60,13 +60,17 @@ The teXt0wnz client is a browser-based text art editor supporting ANSI, ASCII, X
 
 ### Navigation (Keyboard Mode)
 
-| Key           | Action                 |
-| ------------- | ---------------------- |
-| Arrow Keys    | Move cursor            |
-| Home/End      | Line start/end         |
-| Page Up/Down  | Page jump              |
-| Tab/Backspace | Insert tab/delete left |
-| Enter         | New line               |
+| Key              | Action                       |
+| ---------------- | ---------------------------- |
+| Arrow Keys       | Move cursor in any direction |
+| Home             | Move to start of current row |
+| End              | Move to end of current row   |
+| Page Up          | Move cursor up by screen     |
+| Page Down        | Move cursor down by screen   |
+| Cmd/Meta + Left  | Move to start of row         |
+| Cmd/Meta + Right | Move to end of row           |
+| Tab/Backspace    | Insert tab/delete left       |
+| Enter            | Move to next line            |
 
 ### Advanced Editing (Alt + Key)
 
@@ -84,6 +88,28 @@ The teXt0wnz client is a browser-based text art editor supporting ANSI, ASCII, X
 | ----- | -------------- |
 | [ / ] | Flip selection |
 | M     | Move mode      |
+
+### Selection Navigation
+
+| Key              | Action                               |
+| ---------------- | ------------------------------------ |
+| Arrow Keys       | Move selection by one cell           |
+| Shift + Arrow    | Expand/shrink selection              |
+| Home             | Expand selection to row start        |
+| End              | Expand selection to row end          |
+| Page Up          | Move selection up by screen height   |
+| Page Down        | Move selection down by screen height |
+| Cmd/Meta + Left  | Expand selection to row start        |
+| Cmd/Meta + Right | Expand selection to row end          |
+| [                | Flip selection horizontally          |
+| ]                | Flip selection vertically            |
+| M                | Toggle move mode                     |
+
+**In Move Mode:**
+
+- **Arrow Keys** - Move selected content by one cell
+- **Page Up** - Move selected content up by screen height
+- **Page Down** - Move selected content down by screen height
 
 ### Special Function Keys (F1-F12)
 
@@ -119,11 +145,17 @@ The editor includes predefined character sets (box drawing, symbols, accented le
 
 ### Mouse Controls
 
-- **Left Click:** Draw
-- **Drag:** Draw/Shape
+- **Left Click:** Draw (in tools), position cursor (on canvas in keyboard mode)
+- **Click and Drag:** Draw/Shape, or create selection
 - **Shift+Click:** Straight line (freehand)
 - **Alt+Click:** Sample color/alt draw
 - **Right Click:** Context menu
+
+**Selection Tool Mouse Behavior:**
+
+- **Single Click:** Move cursor to clicked position (does not create selection)
+- **Click and Drag:** Create or expand selection by dragging to different cell
+- **In Move Mode:** Drag within selection to move selected content
 
 ## Color Management
 
@@ -243,6 +275,23 @@ The editor works as a Progressive Web App:
 8. Use F-keys for quick access to block characters
 9. Alt+Click to sample colors from artwork
 10. Undo/Redo freely (up to 1000 operations stored)
+
+## Screen-Aware Navigation
+
+Page Up and Page Down automatically calculate movement based on the current viewport height and font size, allowing you to navigate large canvases one screen at a time without losing your bearings.
+
+**In Keyboard Mode:**
+
+- Canvas cursor moves by one full screen height
+- Viewport automatically scrolls to keep cursor visible
+
+**In Selection Tool:**
+
+- Selection moves by one full screen height in default mode
+- In move mode, selected content moves by one full screen height
+- Viewport automatically scrolls to keep selection visible
+
+This makes navigation much faster and more intuitive on large text art pieces.
 
 ## Browser Support
 

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -127,18 +127,26 @@ See [editor-client.md](editor-client.md) for detailed tool descriptions and [pro
 
 ## ![keyboard](https://raw.githubusercontent.com/wiki/xero/text0wnz/img/keyboard.png) Keyboard Mode
 
-Full text input with navigation controls. Type characters directly onto the canvas. Use the F-keys to insert block shading characters (`░▒▓`) like traditional ANSI editors. Navigate the canvas with the arrow keys, home/end, and page up/down.
+Full text input with navigation controls. Type characters directly onto the canvas. Use the F-keys to insert block shading characters (`░▒▓`) like traditional ANSI editors.
 
 **Features:**
 
 - Direct character input
 - F-key block character insertion
 - Ctrl+[ / ] to swap character sets
-- Arrow key navigation
-- Home/End row navigation
-- Page Up/Down column navigation
 - Traditional ANSI editor workflow
 - Shift+Arrow keys switches to the Selection Tool
+
+**Navigation:**
+
+- **Arrow Keys** - Move cursor in any direction
+- **Home** - Move to start of current row
+- **End** - Move to end of current row
+- **Page Up** - Move cursor up by one screen height
+- **Page Down** - Move cursor down by one screen height
+- **Cmd/Meta + Left Arrow** - Move to start of current row
+- **Cmd/Meta + Right Arrow** - Move to end of current row
+- **Enter** - Move to next line (start of new row)
 
 ![f-key legend](https://raw.githubusercontent.com/wiki/xero/text0wnz/img/fkeys.png)
 
@@ -250,32 +258,44 @@ See [architecture.md](architecture.md) for shape rendering algorithms.
 
 ![selection-menu](https://raw.githubusercontent.com/wiki/xero/text0wnz/img/selection-menu.png)
 
-Visually highlight rectangular sections of the canvas and apply transformations to it.
+Visually highlight rectangular sections of the canvas and apply transformations to it. The selection position is displayed in the status bar in real-time as you manipulate it.
 
-**Keyboard:**
+**Keyboard Navigation:**
 
-- Arrow keys: Movement
-  - Default: Move the selection
-  - Move Mode: Move the selection _and it's contents_
-- Shift + Arrow keys: Grow/Shrink selection
-- Meta + left/right: Expand selection to canvas bounds
+- **Arrow Keys** - Move selection by one cell
+  - Default: Move the selection box
+  - Move Mode: Move the selection _and its contents_
+- **Shift + Arrow Keys** - Expand/shrink selection
+- **Home** - Expand selection to start of current row
+- **End** - Expand selection to end of current row
+- **Page Up** - Move selection up by one screen height
+- **Page Down** - Move selection down by one screen height
+- **Cmd/Meta + Left Arrow** - Expand selection to start of current row
+- **Cmd/Meta + Right Arrow** - Expand selection to end of current row
 
 **Mouse/Touch:**
 
-- In an unselected area: New selection
-- Within a selection:
-  - Default: Move the selection
-  - Move Mode: Move the selection _and it's contents_
+- **Click in unselected area** - Create new selection
+- **Click and drag** - Create or expand selection to different cell
+- **Within a selection (default mode)** - Move the selection box
+- **Within a selection (move mode)** - Move the selection _and its contents_
+
+> [!NOTE]
+> Single clicks move the cursor without creating a selection. Drag to create a selection to prevent accidental single-cell selections.
+
+**Viewport Auto-Scroll:**
+
+When navigating selections with keyboard or mouse, the viewport automatically scrolls to keep the selection visible with a buffer zone, similar to cursor navigation.
 
 **Operations:**
 
-- Flip Horizontally
-- Flip Vertically
-- Move
-- Cut
-- Copy
-- Paste (from app clipboard)
-- System Paste (from operating system clipboard)
+- Flip Horizontally (`[` key)
+- Flip Vertically (`]` key)
+- Move Mode (`M` key) - Toggle orange move mode
+- Cut (`Ctrl+X`)
+- Copy (`Ctrl+C`)
+- Paste from app clipboard (`Ctrl+V`)
+- System Paste from OS clipboard (`Ctrl+Shift+V`)
 
 **Selection Modes:**
 
@@ -283,7 +303,7 @@ The default selection mode is white:
 
 ![selection](https://raw.githubusercontent.com/wiki/xero/text0wnz/img/selection.png)
 
-Move mode is orange:
+Move mode is orange (toggle with `M` key):
 
 ![move](https://raw.githubusercontent.com/wiki/xero/text0wnz/img/move.png)
 
@@ -293,6 +313,9 @@ Move mode is orange:
 - **Ctrl+C** - Copy selection
 - **Ctrl+V** - Paste from app clipboard
 - **Ctrl+Shift+V** - Paste from system clipboard
+- **[** - Flip horizontally
+- **]** - Flip vertically
+- **M** - Toggle move mode
 
 See [editor-client.md](editor-client.md) for more keyboard shortcuts and clipboard operations.
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -542,13 +542,12 @@
 		span {
 			@apply flex flex-col mx-1 my-auto;
 			margin-top: -5px;
+			&:hover canvas {
+				outline: 1px solid var(--cyber);
+			}
 			canvas {
 				scale: 1.5;
 				margin: 3px auto auto auto;
-
-				&:hover {
-					outline: 1px solid var(--cyber);
-				}
 			}
 		}
 	}
@@ -607,8 +606,9 @@
 	}
 
 	#positionInfo {
-		@apply flex flex-row text-right text-fg text-xs ml-1 min-w-[50px];
-		line-height: 20px;
+		@apply flex flex-row text-fg text-xs mr-1 min-w-[50px];
+		padding: 5px 2px 2px 3px;
+		word-spacing: -6px;
 	}
 
 	#canvasContainer {
@@ -1174,6 +1174,7 @@
 	#resolution,
 	#selectionToolbar .toolButton,
 	#currentFontDisplay,
+	#keyboardToolbar span,
 	#chatButton {
 		@apply cursor-pointer;
 	}

--- a/src/index.html
+++ b/src/index.html
@@ -91,18 +91,18 @@
 								<use href="img/icons.svg#left"></use>
 							</svg>
 						</button>
-						<span>F1<canvas id="fkey0" class="fkey" height="0" width="0"></canvas></span>
-						<span>F2<canvas id="fkey1" class="fkey" height="0" width="0"></canvas></span>
-						<span>F3<canvas id="fkey2" class="fkey" height="0" width="0"></canvas></span>
-						<span>F4<canvas id="fkey3" class="fkey" height="0" width="0"></canvas></span>
-						<span>F5<canvas id="fkey4" class="fkey" height="0" width="0"></canvas></span>
-						<span>F6<canvas id="fkey5" class="fkey" height="0" width="0"></canvas></span>
-						<span>F7<canvas id="fkey6" class="fkey" height="0" width="0"></canvas></span>
-						<span>F8<canvas id="fkey7" class="fkey" height="0" width="0"></canvas></span>
-						<span>F9<canvas id="fkey8" class="fkey" height="0" width="0"></canvas></span>
-						<span>F10<canvas id="fkey9" class="fkey" height="0" width="0"></canvas></span>
-						<span>F11<canvas id="fkey10" class="fkey" height="0" width="0"></canvas></span>
-						<span>F12<canvas id="fkey11" class="fkey" height="0" width="0"></canvas></span>
+						<span id="fkey0w">F1<canvas id="fkey0" class="fkey" height="0" width="0"></canvas></span>
+						<span id="fkey1w">F2<canvas id="fkey1" class="fkey" height="0" width="0"></canvas></span>
+						<span id="fkey2w">F3<canvas id="fkey2" class="fkey" height="0" width="0"></canvas></span>
+						<span id="fkey3w">F4<canvas id="fkey3" class="fkey" height="0" width="0"></canvas></span>
+						<span id="fkey4w">F5<canvas id="fkey4" class="fkey" height="0" width="0"></canvas></span>
+						<span id="fkey5w">F6<canvas id="fkey5" class="fkey" height="0" width="0"></canvas></span>
+						<span id="fkey6w">F7<canvas id="fkey6" class="fkey" height="0" width="0"></canvas></span>
+						<span id="fkey7w">F8<canvas id="fkey7" class="fkey" height="0" width="0"></canvas></span>
+						<span id="fkey8w">F9<canvas id="fkey8" class="fkey" height="0" width="0"></canvas></span>
+						<span id="fkey9w">F10<canvas id="fkey9" class="fkey" height="0" width="0"></canvas></span>
+						<span id="fkey10w">F11<canvas id="fkey10" class="fkey" height="0" width="0"></canvas></span>
+						<span id="fkey11w">F12<canvas id="fkey11" class="fkey" height="0" width="0"></canvas></span>
 						<button id="fkeySetNext" aria-label="Next">
 							<svg>
 								<use href="img/icons.svg#right"></use>

--- a/src/js/client/keyboard.js
+++ b/src/js/client/keyboard.js
@@ -186,12 +186,18 @@ const createFKeys = () => {
 };
 
 const calculateRowsPerScreen = (viewport, fontHeight) => {
+	if (!viewport) {
+		return 0;
+	}
 	return Math.floor(viewport.clientHeight / fontHeight);
 };
 
 const createCursor = canvasContainer => {
 	const canvas = createCanvas(State.font.getWidth(), State.font.getHeight());
 	const viewport = $('viewport');
+	if (!viewport) {
+		console.error('viewport element missing, focus scroll disabled');
+	}
 	let x = 0;
 	let y = 0;
 	let visible = false;
@@ -1971,15 +1977,16 @@ const createSelectionTool = () => {
 	const keyDown = e => {
 		// These keys work with or without modifiers
 		if (e.code === 'Enter') {
+			// Enter - exit selection and use default cursor behavior
 			e.preventDefault();
 			Toolbar.switchTool('keyboard');
 			State.cursor.newLine();
-			// End key - expand selection to end of current row
 		} else if (e.code === 'End') {
+			// End key - expand selection to end of current row
 			e.preventDefault();
 			shiftToEndOfRow();
-			// Home key - expand selection to start of current row
 		} else if (e.code === 'Home') {
+			// Home key - expand selection to start of current row
 			e.preventDefault();
 			shiftToStartOfRow();
 		}


### PR DESCRIPTION
New drag-to-select logic prevents accidental selections, synced viewport scrolling keeps your bearings, and Page Up/Down with screen-aware sizing making large canvas navigation much faster!

# New Features
1. **Page Up/Down Navigation (cursor)**
   - `PageUp` / `PageDown` - Move cursor by full screen height
   - Properly clamps to canvas bounds
   - Works in keyboard mode
   - Page Up/Down in Selection Mode

2. **PageUp / PageDown - Move selection by full screen height**
   - Works in normal selection expansion mode
   - Also works in move mode to move selected content by a screen height

3. **Viewport Auto-Scroll for Selection**
   - New scrollViewportToSelection() function
   - Automatically scrolls viewport to keep selection visible (similar to cursor behavior)
   - Called after Page Up/Down operations to maintain focus

4. **Position Info Display**
   - Selection cursor now updates State.positionInfo with its top-left corner position in setEnd()
   - Displays selection position in real-time as you manipulate it
   
5. **Selection Tool Keyboard Improvements**

   - `Home` - Expand selection to start of current row
   - `End` - Expand selection to end of current row
These now call shiftToStartOfRow() and shiftToEndOfRow() instead of switching tools

# Changed Behavior

1. **Smart Single-Cell Selection Prevention:**
   - Mouse Selection: Requires dragging to actually create a selection (clicks just move cursor)
   - Changed textCanvasDown to store position but not create selection
   - textCanvasDrag only switches to selection tool if you drag to a different cell
   - Eliminates accidental single-cell selections from clicks

2. **Keybinds:**
   - Cursor PageUp/Down: Now calculates screen size dynamically based on viewport height and font size
